### PR TITLE
Fix lib build warnings

### DIFF
--- a/src/components/Core/Formfield/Label.tsx
+++ b/src/components/Core/Formfield/Label.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React, {ComponentProps} from 'react'
 
-interface LabelProps extends React.ComponentProps<'label'> {
+export interface LabelProps extends React.ComponentProps<'label'> {
     labelName?: string;
     className?: string;
     children?: React.ReactNode

--- a/src/components/Core/Formfield/Select.tsx
+++ b/src/components/Core/Formfield/Select.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import React from 'react'
 
-interface SelectProps extends React.ComponentProps<'select'> {
+export interface SelectProps extends React.ComponentProps<'select'> {
     values?: number[]
     className?: string
 }

--- a/src/components/Core/Formfield/TextInput.tsx
+++ b/src/components/Core/Formfield/TextInput.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import React from 'react'
-interface TextInputProps extends React.ComponentProps<'input'> {
+export interface TextInputProps extends React.ComponentProps<'input'> {
     searchValue?: string
     placeholder?: string
     className?: string

--- a/src/components/Templates/DashBoard/User.tsx
+++ b/src/components/Templates/DashBoard/User.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const User = () => {
+export const User = ({ userName }: { userName: string }) => {
   return (
     <div className='w-full pl-[24px] mb-20 h-[64px] flex items-center gap-[12px]  '>
           <h2 className='font-bold tracking-[0.05em] text-[24px] text-[#d9d9d9] '>GM,</h2>

--- a/src/components/WhoisInfo/CardHeader.tsx
+++ b/src/components/WhoisInfo/CardHeader.tsx
@@ -1,5 +1,4 @@
 import React, { ComponentProps } from 'react'
-import { WhoisLinkButton } from '../LinkButton'
 
 export const CardHeader: React.FC<ComponentProps<'div'>> = ({children, ...props}) => {
   return (


### PR DESCRIPTION
Fix some warnings

```
→ yarn build:lib                                                                                                 
yarn run v1.22.21                                                                                                
$ rimraf lib && rollup -c                                                                                        
(!) You have passed an unrecognized option                                                                       
Unknown input options: important. Allowed options: acorn, acornInjectPlugins, cache, context, experimentalCacheEx
piry, experimentalLogSideEffects, external, inlineDynamicImports, input, logLevel, makeAbsoluteExternalsRelative,
 manualChunks, maxParallelFileOps, maxParallelFileReads, moduleContext, onLog, onwarn, perf, plugins, preserveEnt
rySignatures, preserveModules, preserveSymlinks, shimMissingExports, strictDeprecations, treeshake, watch        
                                                                                                                 
src/index.ts → lib/cjs/bundle.js, lib/esm/bundle.js...                                                           
(!) Plugin typescript: @rollup/plugin-typescript TS2304: Cannot find name 'userName'.                            
src/components/Templates/DashBoard/User.tsx: (8:85)                                                              
                                                                                                                 
8           <h2 className='font-[900] tracking-[0.05em] text-[32px] text-[#d9d9d9] '>{userName}</h2>             
                                                                                      ~~~~~~~~                   
                                                                                                                 
(!) Plugin typescript: @rollup/plugin-typescript TS4023: Exported variable 'WhoisForm' has or is using name 'Labe
lProps' from external module "/tmp/d3servelabs/namefi-storybook/src/components/Core/Formf
ield/Label" but cannot be named.                                                                                 
src/components/Templates/WhoisForm/WhoisINfoForm.tsx: (43:14)                                                    
                                                                                                                 
43 export const WhoisForm = {                                                                                    
                ~~~~~~~~~                                                                                        
                                                                                                                 
(!) Plugin typescript: @rollup/plugin-typescript TS4023: Exported variable 'WhoisForm' has or is using name 'Sele
ctProps' from external module "/tmp/d3servelabs/namefi-storybook/src/components/Core/Form
field/Select" but cannot be named.                                                                               
src/components/Templates/WhoisForm/WhoisINfoForm.tsx: (43:14)                                                    
                                                                                                                 
43 export const WhoisForm = {                                                                                    
                ~~~~~~~~~                                                                                        
                                                                                                                 
(!) Plugin typescript: @rollup/plugin-typescript TS4023: Exported variable 'WhoisForm' has or is using name 'Text
InputProps' from external module "/tmp/d3servelabs/namefi-storybook/src/components/Core/F
ormfield/TextInput" but cannot be named.                                                                         
src/components/Templates/WhoisForm/WhoisINfoForm.tsx: (43:14)                                                    
                                                                                                                 
43 export const WhoisForm = {                                                                                    
                ~~~~~~~~~                                                                                        
                                                                                                                 
(!) Plugin typescript: @rollup/plugin-typescript TS2724: '"../LinkButton"' has no exported member named 'WhoisLin
kButton'. Did you mean 'LinkButton'?                                                                             
src/components/WhoisInfo/CardHeader.tsx: (2:10)                                                                  
                                                                                                                 
2 import { WhoisLinkButton } from '../LinkButton'                                                                
           ~~~~~~~~~~~~~~~                                                                                       
                                                                                                                 
  src/components/LinkButton.tsx:15:14                                                                            
    15 export const LinkButton: React.FC<ComponentProps <'button'>> =  () => {                                   
                    ~~~~~~~~~~                                                                                   
    'LinkButton' is declared here.                                                                               
                                                                                                                 
created lib/cjs/bundle.js, lib/esm/bundle.js in 4.8s                                                             
                                                                                                                 
lib/esm/types/index.d.ts → lib/index.d.ts...                                                                     
created lib/index.d.ts in 116ms                                                                                  
Done in 5.91s.         
```