### PR TITLE
feat: add a Chip core component and two stories for it

### DIFF
--- a/src/components/Core/Chip.tsx
+++ b/src/components/Core/Chip.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+
+export type ChipProps = React.ComponentProps<'div'> &
+    Partial<{
+        selected?: boolean;
+        onSelect?: () => void;
+    }>;
+
+export function Chip({ selected,
+    onSelect,
+    children,
+    className,
+    ...props
+}: ChipProps) {
+    return (
+        <div
+            className={cn('py-2.5 px-6.25 flex justify-center items-center border-2 rounded-3xl font-primary text-2.5 md:text-lg cursor-pointer', selected ? 'border-primary-500 bg-black-900 text-white' : 'transition border-[#4a4a4a] bg-[#1c1c1c] text-[#d2d2d2] hover:ring-primary-500 hover:ring-2 hover:ring-inset hover:bg-black-900 hover:text-white', className)} onClick={onSelect} {...props}>
+            {children}
+        </div>
+    );
+};

--- a/src/stories/Components/Chip.stories.tsx
+++ b/src/stories/Components/Chip.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Chip } from "../../components/Core/Chip";
+
+const meta = {
+    title: 'Components/Chip',
+    component: Chip,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'centered'
+    }
+} satisfies Meta<typeof Chip>
+
+export default meta;
+
+type Story = StoryObj<typeof meta>
+
+export const ChipUnselected: Story = {
+    args: {
+        selected: false,
+        children: "chip"
+    }
+}
+export const ChipSelected: Story = {
+    args: {
+        selected: true,
+        children: "chip"
+    }
+}


### PR DESCRIPTION
Add the Chip Core component with two stories, selected and not selected. This will be used in the Get NFSC card.