### PR TITLE
fix: 🐛 ensure consistent line endings (important for cross-platform)

### DIFF
--- a/tooling/eslint/base.js
+++ b/tooling/eslint/base.js
@@ -27,6 +27,7 @@ const config = {
     'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     '@typescript-eslint/no-explicit-any': ['warn'],
     '@typescript-eslint/no-unused-vars': ['warn'],
+    "prettier/prettier": ["error", { "endOfLine": "lf" }]
   },
 };
 module.exports = config;


### PR DESCRIPTION
On Windows machines `Eslint` show weird error

 
![Screenshot 2025-01-07 174731](https://github.com/user-attachments/assets/8cbe7fb4-eae0-4012-87b6-080ef6ead3f8)
